### PR TITLE
Updating file path location search for config.json

### DIFF
--- a/fail2rest.go
+++ b/fail2rest.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"path"
 	"github.com/Sean-Der/fail2go"
 	"github.com/gorilla/mux"
 	"net/http"
@@ -21,7 +22,11 @@ type ErrorBody struct {
 var fail2goConn *fail2go.Conn
 
 func main() {
-	file, fileErr := os.Open("config.json")
+
+	//Changing path of current running directory to path of running executable for finding the config.json file.
+	//This will allow the creation of a linux service to run fail2rest (ie: service fail2rest start/stop/status)
+	var filePath string = path.Dir(os.Args[0])
+	file, fileErr := os.Open(filePath + "/config.json")
 
 	if fileErr != nil {
 		fmt.Println("failed to open config:", fileErr)


### PR DESCRIPTION
Instead of looking for config.json form current directory when running the program, look for the config.json from the executable running directory.  This will allow for calling fail2rest executable from a service w/o getting the "failed to open config: config.json" error.
