### PR TITLE
This is the service for ubuntu

### DIFF
--- a/init-scripts/ubuntu_14_04
+++ b/init-scripts/ubuntu_14_04
@@ -1,16 +1,18 @@
 #! /bin/sh
 ### BEGIN INIT INFO
 #
-# Provides              :       fail2rest 
-# Required-Start        :       $remote_fs
-# Required-Stop         :       $remote_fs
-# Default-Start         :       2 3 4 5
-# Default-Stop          :       0 1 6
-# Short-Description     :       fail2rest initscript
-# Description           :       fail2rest is a small REST server that aims allow full administration of a fail2ban server via HTTP 
+# Provides:             fail2rest
+# Required-Start:       $remote_fs $syslog
+# Required-Stop:        $remote_fs $syslog
+# Should-Start:         fail2ban
+# Should-Stop:          fail2ban
+# Default-Start:        2 3 4 5
+# Default-Stop:         0 1 6
+# Short-Description:    fail2rest initscript
+# Description:          fail2rest is a small REST server that aims allow full administration of a fail2ban server via HTTP
 #
 ### END INIT INFO
-                                                                                                                                                                                              
+
 # PATH should only include /usr/* if it runs after the mountnfs.sh script
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="fail2rest is a small REST server that aims to allow full administration of a fail2ban server via HTTP"
@@ -20,12 +22,6 @@ DAEMON="$DAEMON_DIR/$NAME"
 DAEMON_ARGS="-config=$DAEMON_DIR/config.json"  #CHANGE TO THE NAME OF YOUR FAIL2REST CONFIG FILE NAME AND DIRECTORY IF NEED BE
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
-                                                                                                                                                                                              
-# Exit if the package is not installed
-#[ -x "$DAEMON" ] || exit 0
-                                                                                                                                                                                              
-# Read configuration variable file if it is present
-#[ -r /etc/default/$NAME] && . /etc/default/$NAME
                                                                                                                                                                                               
 # Load the VERBOSE setting and other rcS variables
 . /lib/init/vars.sh


### PR DESCRIPTION
I'm using ubuntu version 14.04.  This is just a custom service for starting fail2rest.  The init script for debian did not work for ubuntu, but this one seems to work w/o any modifications to how fail2rest reads the config file.  I am just passing the config file in using the config flag.
