### PR TITLE
Added controller ip filtering possibility.

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
   "Addr": "127.0.0.1:5000",
-  "Fail2banSocket": "/var/run/fail2ban/fail2ban.sock"
+  "Fail2banSocket": "/var/run/fail2ban/fail2ban.sock",
+  "ControllerIp": "127.0.0.1"
 }


### PR DESCRIPTION
Added possibility to filter controller IP address. With this feature fail2rest could be pointed to non loopback interface and used as endpoint for different controller applications. 